### PR TITLE
Set guid when reading boot entries in read_vars.

### DIFF
--- a/src/efibootmgr/efibootmgr.c
+++ b/src/efibootmgr/efibootmgr.c
@@ -124,6 +124,7 @@ read_vars(char **namelist,
 			entry->attributes = entry->attributes & ~(1 << 31);
 
 			entry->name = namelist[i];
+			entry->guid = EFI_GLOBAL_GUID;
 			list_add_tail(&entry->list, head);
 		}
 	}


### PR DESCRIPTION
In my /sys/firmware/efi/vars/ i have duplicated BootXXXX entries like that:
```
Boot0000-00000000-0000-0000-0000-000000000000
Boot0000-8be4df61-93ca-11d2-aa0d-00e098032b8c
Boot0001-00000000-0000-0000-0000-000000000000
Boot0001-8be4df61-93ca-11d2-aa0d-00e098032b8c
```

Using `efibootmgr -A -b 0001` was not disabling the Boot0001 entry as expected.
It turns out that it was using `Boot0001-00000000-0000-0000-0000-000000000000` instead of `Boot0001-8be4df61-93ca-11d2-aa0d-00e098032b8c` because set_active_state uses `boot->guid` which is set to 0 in read_vars (because of memset() at [src/efibootmgr.c:108](https://github.com/rhinstaller/efibootmgr/blob/ea640b305066f22db08423e95a42f59b01aa5303/src/efibootmgr/efibootmgr.c#L108))

So I set it to EFI_GLOBAL_GUID when reading vars.

FYI, I use that feature to disable Windows boot entry so I can boot Linux without modifying Windows' bootmgfw.efi (my BIOS reset the boot order at every boot so the Windows entry is the first).