### PR TITLE
Fix errors with "Could not parse device path" in efibootmgr -v

### DIFF
--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -848,7 +848,7 @@ show_boot_vars()
 
 			pathlen = efi_loadopt_pathlen(load_option,
 						      boot->data_size);
-			dp = efi_loadopt_path(load_option, pathlen);
+			dp = efi_loadopt_path(load_option, boot->data_size);
 			rc = efidp_format_device_path(text_path, text_path_len,
 						      dp, pathlen);
 			if (rc < 0)


### PR DESCRIPTION
These come up when parsing a path for:
Linux-Firmware-Updater \fwupx64.efi
They're not present in efibootdump.

Before this PR:
```
t@t-XPS-13-9350:~$ efibootmgr 
BootCurrent: 0006
Timeout: 0 seconds
BootOrder: 0001,0002,0003,0004,0006
Boot0000* Linux-Firmware-Updater \fwupx64.efi
Boot0001* Diskette Drive
Boot0002* M.2 PCIe SSD
Boot0003* USB Storage Device
Boot0004* CD/DVD/CD-RW Drive
Boot0006* UEFI: THNSN5512GPU7 NVMe TOSHIBA 512GB, Partition 1

t@t-XPS-13-9350:~$ efibootmgr -v
BootCurrent: 0006
Timeout: 0 seconds
BootOrder: 0001,0002,0003,0004,0006
efibootmgr: Could not parse device path: No such file or directory
```

After this PR:
```
t@t-XPS-13-9350:~$ ./efibootmgr 
BootCurrent: 0006
Timeout: 0 seconds
BootOrder: 0001,0002,0003,0004,0006
Boot0000* Linux-Firmware-Updater \fwupx64.efi
Boot0001* Diskette Drive
Boot0002* M.2 PCIe SSD
Boot0003* USB Storage Device
Boot0004* CD/DVD/CD-RW Drive
Boot0006* UEFI: THNSN5512GPU7 NVMe TOSHIBA 512GB, Partition 1

t@t-XPS-13-9350:~$ ./efibootmgr -v
BootCurrent: 0006
Timeout: 0 seconds
BootOrder: 0001,0002,0003,0004,0006
Boot0000* Linux-Firmware-Updater \fwupx64.efi	HD(1,GPT,25d2718c-2de8-48bc-83eb-a507907006cd,0x800,0xfa000)/File(\EFI\ubuntu\shimx64.efi)\.f.w.u.p.x.6.4...e.f.i...
Boot0001* Diskette Drive	BBS(Floppy,Diskette Drive,0x0)..BO
Boot0002* M.2 PCIe SSD	BBS(HD,THNSN5512GPU7 NVMe TOSHIBA 512G,0x0)..BO
Boot0003* USB Storage Device	BBS(USB,USB Storage Device,0x0)..BO
Boot0004* CD/DVD/CD-RW Drive	BBS(CDROM,CD/DVD/CD-RW Drive,0x0)..BO
Boot0006* UEFI: THNSN5512GPU7 NVMe TOSHIBA 512GB, Partition 1	HD(1,GPT,25d2718c-2de8-48bc-83eb-a507907006cd,0x800,0xfa000)/File(EFI\Ubuntu\shimx64.efi)..BO


```