### PR TITLE
Add support for parsing optional data as ucs2

### DIFF
--- a/src/efibootmgr.8
+++ b/src/efibootmgr.8
@@ -106,7 +106,7 @@ Boot Manager timeout, in \fIseconds\fR\&.
 Delete Timeout variable.
 .TP
 \fB-u | --unicode | --UCS-2 \fR
-pass extra command line arguments as UCS-2 (default is
+Handle extra command line arguments as UCS-2 (default is
 ASCII)
 .TP
 \fB-v | --verbose\fR


### PR DESCRIPTION
Use the -u option to change the output from
`Boot0014* Arch Linux    HD(1,GPT,2d85bd5e-6f9c-4d73-a2b1-49144e09c1a6,0x800,0xf4000)/File(\vmlinuz-linux)c.r.y.p.t.d.e.v.i.c.e.=./.d.e.v./.s.d.a.2.:.c.r.y.p.t.r.o.o.t. .r.o.o.t.=./.d.e.v./.m.a.p.p.e.r./.c.r.y.p.t.r.o.o.t. .r.w. .i.n.i.t.r.d.=./.i.n.t.e.l.-.u.c.o.d.e...i.m.g. .i.n.i.t.r.d.=./.i.n.i.t.r.a.m.f.s.-.l.i.n.u.x...i.m.g. .s.c.s.i._.m.o.d...u.s.e._.b.l.k._.m.q.=.1.`
to
`Boot0014* Arch Linux    HD(1,GPT,2d85bd5e-6f9c-4d73-a2b1-49144e09c1a6,0x800,0xf4000)/File(\vmlinuz-linux)cryptdevice=/dev/sda2:cryptroot root=/dev/mapper/cryptroot rw initrd=/intel-ucode.img initrd=/initramfs-linux.img scsi_mod.use_blk_mq=1`