### PR TITLE
Don't use -fshort-wchar when building

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -26,7 +26,7 @@ clang_cflags =
 gcc_cflags =
 cflags	= $(CFLAGS) $(SUBDIR_CFLAGS) \
 	-Werror -Wall -Wextra -Wsign-compare -Wstrict-aliasing \
-	-std=gnu11 -fshort-wchar -fPIC \
+	-std=gnu11 -fPIC \
 	-D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -DLOCALEDIR=\"$(localedir)\" \
 	-DEFIBOOTMGR_VERSION="\"$(VERSION)\"" \
 	$(if $(findstring clang,$(CC)),$(clang_cflags),) \


### PR DESCRIPTION
Hi Peter,

As discussed in IRC - it's not needed and is causing build failures with gcc 6. Closes
Debian bug #849651

Signed-off-by: Steve McIntyre <steve@einval.com>
