### PR TITLE
efibootmgr: sanitize `set/get_mirror()`

### DIFF
--- a/src/efibootdump.c
+++ b/src/efibootdump.c
@@ -39,7 +39,7 @@ print_boot_entry(efi_load_option *loadopt, size_t data_size)
 	uint8_t *optional_data = NULL;
 	size_t optional_data_len = 0;
 	uint16_t pathlen;
-	const unsigned char const *desc;
+	const unsigned char *desc;
 	char *raw;
 	size_t raw_len;
 

--- a/src/efibootmgr.8
+++ b/src/efibootmgr.8
@@ -106,7 +106,7 @@ Boot Manager timeout, in \fIseconds\fR\&.
 Delete Timeout variable.
 .TP
 \fB-u | --unicode | --UCS-2 \fR
-pass extra command line arguments as UCS-2 (default is
+Handle extra command line arguments as UCS-2 (default is
 ASCII)
 .TP
 \fB-v | --verbose\fR

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1106,12 +1106,12 @@ get_mirror(int which, int *below4g, int *above4g, int *mirrorstatus)
 	if (rc == 0) {
 		abm = (ADDRESS_RANGE_MIRROR_VARIABLE_DATA *)data;
 		if (!which && abm->mirror_version != MIRROR_VERSION) {
-			warningx("** Warning ** : unrecognised version for memory mirror i/f");
-			return 2;
+			rc = 2;
 		}
 		*below4g = abm->mirror_memory_below_4gb;
 		*above4g = abm->mirror_amount_above_4gb;
 		*mirrorstatus = abm->mirror_status;
+		free(data);
 	} else {
 		cond_warning(opts.verbose >= 2,
 			     "Could not read variable '%s'", name);
@@ -1130,13 +1130,18 @@ set_mirror(int below4g, int above4g)
 	uint32_t attributes;
 	int oldbelow4g, oldabove4g;
 
-	if ((s = get_mirror(0, &oldbelow4g, &oldabove4g, &status)) == 0) {
-		if (oldbelow4g == below4g && oldabove4g == above4g)
-			return 0;
-	} else {
-		warningx("** Warning ** : platform does not support memory mirror");
+	if ((s = get_mirror(0, &oldbelow4g, &oldabove4g, &status)) != 0) {
+		if (s == 2)
+			warningx("** Warning ** : unrecognised version for memory mirror i/f");
+		else
+			warningx("** Warning ** : platform does not support memory mirror");
 		return s;
 	}
+
+	below4g = opts.set_mirror_lo ? below4g : oldbelow4g;
+	above4g = opts.set_mirror_hi ? above4g : oldabove4g;
+	if (oldbelow4g == below4g && oldabove4g == above4g)
+		return 0;
 
 	data = (uint8_t *)&abm;
 	data_size = sizeof (abm);
@@ -1145,10 +1150,9 @@ set_mirror(int below4g, int above4g)
 		| EFI_VARIABLE_RUNTIME_ACCESS;
 
 	abm.mirror_version = MIRROR_VERSION;
-	abm.mirror_amount_above_4gb = opts.set_mirror_hi ? above4g : oldabove4g;
-	abm.mirror_memory_below_4gb = opts.set_mirror_lo ? below4g : oldbelow4g;
+	abm.mirror_amount_above_4gb = above4g;
+	abm.mirror_memory_below_4gb = below4g;
 	abm.mirror_status = 0;
-	data = (uint8_t *)&abm;
 	rc = efi_set_variable(ADDRESS_RANGE_MIRROR_VARIABLE_GUID,
 			      ADDRESS_RANGE_MIRROR_VARIABLE_REQUEST, data,
 			      data_size, attributes, 0644);

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -221,7 +221,7 @@ warn_duplicate_name(list_t *var_list)
 	list_t *pos;
 	var_entry_t *entry;
 	efi_load_option *load_option;
-	const unsigned char const *desc;
+	const unsigned char *desc;
 
 	list_for_each(pos, var_list) {
 		entry = list_entry(pos, var_entry_t, list);
@@ -873,7 +873,7 @@ show_vars(const char *prefix)
 {
 	list_t *pos;
 	var_entry_t *boot;
-	const unsigned char const *description;
+	const unsigned char *description;
 	efi_load_option *load_option;
 	efidp dp = NULL;
 	unsigned char *optional_data = NULL;


### PR DESCRIPTION
get_mirror()
- don't short-circuit the assignment of values in case of version mismatch
  as `show_mirror()` happily tries to use them nevertheless
- move redundant warning (from `show_mirror()`s PoV) to `set_mirror()`
- add missing `free(data)`

set_mirror()
- skip obsolete second assignment of `data`
- avoid potentially "uninitialized" access to `above/below4g` by protecting
  it with `opts.set_mirror_hi/_lo` respectively, thus simplifying the code
  down the line
Note: this will prevent unnecessary write-operations!